### PR TITLE
Add link to Server Side Dev Docs and run auto formatter

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,14 +54,14 @@
         <img alt="BlockBot" src="assets/blockbot.png"/> <br/>
         <p>Blockbot is a server-side mod for 1.16 and later which allows you to link your server chat with a discord
             channel. BlockBot also has an API which could allow BlockBot functionality for platforms other than discord</p>
-        <a href="https://github.com/QuiltServerTools/HeyThatsMine"><img alt="GitHub" src="assets/github-32x.png"/></a>
+        <a href="https://github.com/QuiltServerTools/blockbot"><img alt="GitHub" src="assets/github-32x.png"/></a>
     </div>
     <br/>
     <div>
         <h2>TickTools</h2>
         <img alt="TickTools" src="assets/ticktools.png"/> <br/>
         <p>TickTools is a server-side mod for 1.17 and later which adds performance options like no-tick view distance and dynamic tick distances</p>
-        <a href="https://github.com/QuiltServerTools/HeyThatsMine"><img alt="GitHub" src="assets/github-32x.png"/></a>
+        <a href="https://github.com/QuiltServerTools/ticktools"><img alt="GitHub" src="assets/github-32x.png"/></a>
     </div>
     <br/>
     <div>

--- a/index.html
+++ b/index.html
@@ -61,7 +61,13 @@
         <p>TickTools is a server-side mod for 1.17 and later which adds performance options like no-tick view distance and dynamic tick distances</p>
         <a href="https://github.com/QuiltServerTools/HeyThatsMine"><img src="assets/github-32x.png" alt="GitHub" /></a>
     </div>
-
+    <br />
+    <div>
+        <h2>Server Side Development Documentation</h2>
+        <p>We have been writing some documentation for those who wish to start out with server side mod development. These documents cover a wide range of topic areas for you to read</p>
+        <a href="https://quiltservertools.github.io/ServerSideDevDocs">Read the docs here!</a><br />
+        <a href="https://github.com/quiltservertools.github.io"><img src="assets/github-32x.png" alt="Github" /></a>
+    </div>
 </div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -18,40 +18,34 @@
 <div style="padding:10px; width: 100%; text-align: center">
     <h1>About us</h1>
     <br/>
-    <p>We aim to create high-quality Minecraft mods for Fabric (and in the future Quilt) servers, making them a viable
-        alternative to bukkit based servers</p>
+    <p>We aim to create high-quality Minecraft mods for Fabric (and in the future Quilt) servers, making them a viable alternative to bukkit based servers</p>
     <br/>
     <div>
         <h2>Discuss</h2>
         <p>Discussion takes place on <a href="https://discord.gg/cSWma7DupQ">our Discord server</a></p>
         <br/>
-        <p>All our code is licensed under a permissive, copyleft license, providing a nice change of pace for many
-            developers</p>
+        <p>All our code is licensed under a permissive, copyleft license, providing a nice change of pace for many developers</p>
     </div>
     <br/>
     <div>
         <h2>Ledger</h2>
         <img alt="Ledger Screenshot" src="assets/ledger-background.png"/> <br/> <br/>
         <p>Ledger is a server-side mod for 1.17 and later, which logs interactions with the world and allows for lookup
-            and rollback. Ledger also has support for Watson, which allows for client-side graphical lookup of the
-            logs</p>
+            and rollback. Ledger also has support for Watson, which allows for client-side graphical lookup of the logs</p>
         <a href="https://github.com/QuiltServerTools/Ledger"><img alt="GitHub" src="assets/github-32x.png"/></a>
     </div>
     <br/>
     <div>
         <h2>Interdimensional</h2>
         <img alt="Interdimensional" src="assets/interdimensional-banner.png" style="max-height: 540px"/> <br/>
-        <p>Interdimensional is a server-side mod for 1.17 and later, which allows for the creation and management of
-            custom dimensions</p>
-        <a href="https://github.com/QuiltServerTools/Interdimensional"><img alt="GitHub"
-                                                                            src="assets/github-32x.png"/></a>
+        <p>Interdimensional is a server-side mod for 1.17 and later, which allows for the creation and management of custom dimensions</p>
+        <a href="https://github.com/QuiltServerTools/Interdimensional"><img alt="GitHub" src="assets/github-32x.png"/></a>
     </div>
     <br/>
     <div>
         <h2>Hey That's Mine</h2>
         <img alt="Hey That's Mine" src="assets/htm.png"/> <br/>
-        <p>Hey That's Mine is a server-side mod for 1.16 and later, providing container locking and trusting
-            functionality</p>
+        <p>Hey That's Mine is a server-side mod for 1.16 and later, providing container locking and trusting functionality</p>
         <a href="https://github.com/QuiltServerTools/HeyThatsMine"><img alt="GitHub" src="assets/github-32x.png"/></a>
     </div>
     <br/>
@@ -59,16 +53,14 @@
         <h2>BlockBot</h2>
         <img alt="BlockBot" src="assets/blockbot.png"/> <br/>
         <p>Blockbot is a server-side mod for 1.16 and later which allows you to link your server chat with a discord
-            channel. BlockBot also has an API which could allow BlockBot functionality for platforms other than
-            discord</p>
+            channel. BlockBot also has an API which could allow BlockBot functionality for platforms other than discord</p>
         <a href="https://github.com/QuiltServerTools/HeyThatsMine"><img alt="GitHub" src="assets/github-32x.png"/></a>
     </div>
     <br/>
     <div>
         <h2>TickTools</h2>
         <img alt="TickTools" src="assets/ticktools.png"/> <br/>
-        <p>TickTools is a server-side mod for 1.17 and later which adds performance options like no-tick view distance
-            and dynamic tick distances</p>
+        <p>TickTools is a server-side mod for 1.17 and later which adds performance options like no-tick view distance and dynamic tick distances</p>
         <a href="https://github.com/QuiltServerTools/HeyThatsMine"><img alt="GitHub" src="assets/github-32x.png"/></a>
     </div>
     <br/>

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>QuiltServerTools</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
-          integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    <link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
+          integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" rel="stylesheet">
     <link href="style.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -17,56 +17,67 @@
 </div>
 <div style="padding:10px; width: 100%; text-align: center">
     <h1>About us</h1>
-    <br />
-    <p>We aim to create high-quality Minecraft mods for Fabric (and in the future Quilt) servers, making them a viable alternative to bukkit based servers</p>
-    <br />
+    <br/>
+    <p>We aim to create high-quality Minecraft mods for Fabric (and in the future Quilt) servers, making them a viable
+        alternative to bukkit based servers</p>
+    <br/>
     <div>
         <h2>Discuss</h2>
         <p>Discussion takes place on <a href="https://discord.gg/cSWma7DupQ">our Discord server</a></p>
-        <br />
-        <p>All our code is licensed under a permissive, copyleft license, providing a nice change of pace for many developers</p>
+        <br/>
+        <p>All our code is licensed under a permissive, copyleft license, providing a nice change of pace for many
+            developers</p>
     </div>
-    <br />
+    <br/>
     <div>
         <h2>Ledger</h2>
-        <img src="assets/ledger-background.png" alt="Ledger Screenshot" /> <br /> <br />
-        <p>Ledger is a server-side mod for 1.17 and later, which logs interactions with the world and allows for lookup and rollback. Ledger also has support for Watson, which allows for client-side graphical lookup of the logs</p>
-        <a href="https://github.com/QuiltServerTools/Ledger"><img src="assets/github-32x.png" alt="GitHub" /></a>
+        <img alt="Ledger Screenshot" src="assets/ledger-background.png"/> <br/> <br/>
+        <p>Ledger is a server-side mod for 1.17 and later, which logs interactions with the world and allows for lookup
+            and rollback. Ledger also has support for Watson, which allows for client-side graphical lookup of the
+            logs</p>
+        <a href="https://github.com/QuiltServerTools/Ledger"><img alt="GitHub" src="assets/github-32x.png"/></a>
     </div>
-    <br />
+    <br/>
     <div>
         <h2>Interdimensional</h2>
-        <img src="assets/interdimensional-banner.png" alt="Interdimensional" style="max-height: 540px" /> <br />
-        <p>Interdimensional is a server-side mod for 1.17 and later, which allows for the creation and management of custom dimensions</p>
-        <a href="https://github.com/QuiltServerTools/Interdimensional"><img src="assets/github-32x.png" alt="GitHub" /></a>
+        <img alt="Interdimensional" src="assets/interdimensional-banner.png" style="max-height: 540px"/> <br/>
+        <p>Interdimensional is a server-side mod for 1.17 and later, which allows for the creation and management of
+            custom dimensions</p>
+        <a href="https://github.com/QuiltServerTools/Interdimensional"><img alt="GitHub"
+                                                                            src="assets/github-32x.png"/></a>
     </div>
-    <br />
+    <br/>
     <div>
         <h2>Hey That's Mine</h2>
-        <img src="assets/htm.png" alt="Hey That's Mine" /> <br />
-        <p>Hey That's Mine is a server-side mod for 1.16 and later, providing container locking and trusting functionality</p>
-        <a href="https://github.com/QuiltServerTools/HeyThatsMine"><img src="assets/github-32x.png" alt="GitHub" /></a>
+        <img alt="Hey That's Mine" src="assets/htm.png"/> <br/>
+        <p>Hey That's Mine is a server-side mod for 1.16 and later, providing container locking and trusting
+            functionality</p>
+        <a href="https://github.com/QuiltServerTools/HeyThatsMine"><img alt="GitHub" src="assets/github-32x.png"/></a>
     </div>
-    <br />
+    <br/>
     <div>
         <h2>BlockBot</h2>
-        <img src="assets/blockbot.png" alt="BlockBot" /> <br />
-        <p>Blockbot is a server-side mod for 1.16 and later which allows you to link your server chat with a discord channel. BlockBot also has an API which could allow BlockBot functionality for platforms other than discord</p>
-        <a href="https://github.com/QuiltServerTools/HeyThatsMine"><img src="assets/github-32x.png" alt="GitHub" /></a>
+        <img alt="BlockBot" src="assets/blockbot.png"/> <br/>
+        <p>Blockbot is a server-side mod for 1.16 and later which allows you to link your server chat with a discord
+            channel. BlockBot also has an API which could allow BlockBot functionality for platforms other than
+            discord</p>
+        <a href="https://github.com/QuiltServerTools/HeyThatsMine"><img alt="GitHub" src="assets/github-32x.png"/></a>
     </div>
-    <br />
+    <br/>
     <div>
         <h2>TickTools</h2>
-        <img src="assets/ticktools.png" alt="TickTools" /> <br />
-        <p>TickTools is a server-side mod for 1.17 and later which adds performance options like no-tick view distance and dynamic tick distances</p>
-        <a href="https://github.com/QuiltServerTools/HeyThatsMine"><img src="assets/github-32x.png" alt="GitHub" /></a>
+        <img alt="TickTools" src="assets/ticktools.png"/> <br/>
+        <p>TickTools is a server-side mod for 1.17 and later which adds performance options like no-tick view distance
+            and dynamic tick distances</p>
+        <a href="https://github.com/QuiltServerTools/HeyThatsMine"><img alt="GitHub" src="assets/github-32x.png"/></a>
     </div>
-    <br />
+    <br/>
     <div>
         <h2>Server Side Development Documentation</h2>
-        <p>We have been writing some documentation for those who wish to start out with server side mod development. These documents cover a wide range of topic areas for you to read</p>
-        <a href="https://quiltservertools.github.io/ServerSideDevDocs">Read the docs here!</a><br />
-        <a href="https://github.com/quiltservertools.github.io"><img src="assets/github-32x.png" alt="Github" /></a>
+        <p>We have been writing some documentation for those who wish to start out with server side mod development.
+            These documents cover a wide range of topic areas for you to read</p>
+        <a href="https://quiltservertools.github.io/ServerSideDevDocs">Read the docs here!</a><br/>
+        <a href="https://github.com/quiltservertools.github.io"><img alt="Github" src="assets/github-32x.png"/></a>
     </div>
 </div>
 </body>

--- a/style.css
+++ b/style.css
@@ -9,5 +9,4 @@
 .badge-container {
     width: 100%;
     text-align: center;
-
 }


### PR DESCRIPTION
Here I added a link to https://quiltservertools.github.io/ServerSideDevDocs at the bottom of the page. I then ran the IntelliJ Auto-formatter on the code. I split that into a separate commit so it can be ignored if so desired.
To view the page now see: https://nocomment1105.github.io/quiltservertools

Also fixes #2 